### PR TITLE
Add a "cloud" profile and use it to configure Redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 bin
 build
 dump.rdb
+xd

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 The following examples demonstrate running the *ticktock* stream (`time | log`). First, we show how to run them as standalone modules. Next, we show how to run each module as an independently scalable app (LRP) on Lattice.
 
+## Pre-requisites
+
+You need Java (8) to build this project. You also need some Spring Cloud connectors that are not yet released. To get those, you will also need Maven (3). Do this:
+
+```
+$ git clone https://github.com/spring-cloud/spring-cloud-lattice
+$ cd spring-cloud-lattice && mvn install --settings=.settings.xml
+$ git clone https://github.com/markfisher/receptor-client
+$ cd receptor-client && ./gradlew install
+```
+
 ## Running Standalone
 
 0: Start redis

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ The following examples demonstrate running the *ticktock* stream (`time | log`).
 
 ## Running Standalone
 
+0: Start redis
+
 1: clone this repository
 
-2: copy modules to */opt/xd/modules*:
+2: download [Spring XD](http://projects.spring.io/spring-xd/) and copy the modules to */opt/xd/modules*:
 
 ````
 opt
@@ -32,6 +34,14 @@ $ java -Dmodule=ticktock.source.time.0 -Dserver.port=8081 -jar xolpoc-0.0.1-SNAP
 ````
 
 **NOTE: at least one of the module processes needs to have an explicit `server.port` property, as shown above, to avoid conflicts on the default (8080)**
+
+See it working by watching the console in the first (sink) process, every second you see one of these:
+
+```
+...
+[2015-05-15 13:34:25.267] boot - 28094  INFO [inbound.ticktock.0-redis:queue-inbound-channel-adapter1] --- ticktock: 2015-05-15 13:34:25
+...
+```
 
 ## Running on Lattice
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ See it working by watching the console in the first (sink) process, every second
 ...
 ```
 
+> NOTE: instead of `/opt/xd` you can use a local directory, e.g. a symlink from the XD distro to the current directory, and launch the apps with `--xdHome=<pathToXD>`.
+
 ## Running on Lattice
 
 1: launch lattice with vagrant as described [here](https://github.com/cloudfoundry-incubator/lattice#launching-with-vagrant)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '1.2.1.RELEASE'
+		springBootVersion = '1.2.3.RELEASE'
 	}
 	repositories {
 		mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	compile("org.springframework.xd:spring-xd-dirt:1.2.0.BUILD-SNAPSHOT") {
 		exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
 	}
+	compile("org.springframework.cloud:spring-cloud-lattice-core:1.0.2.BUILD-SNAPSHOT")
 	compile("org.springframework.cloud:spring-cloud-lattice-connector:1.0.2.BUILD-SNAPSHOT")
 	testCompile("org.springframework.boot:spring-boot-starter-test")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 		exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
 	}
 	compile("org.springframework.boot:spring-boot-starter-log4j")
+	compile("org.springframework.boot:spring-boot-configuration-processor")
 	compile("org.springframework.xd:spring-xd-messagebus-redis:1.2.0.BUILD-SNAPSHOT")
 	compile("org.springframework.xd:spring-xd-messagebus-rabbit:1.2.0.BUILD-SNAPSHOT")
 	compile("org.springframework.xd:spring-xd-dirt:1.2.0.BUILD-SNAPSHOT") {

--- a/src/main/java/xolpoc/app/ModuleBootstrap.java
+++ b/src/main/java/xolpoc/app/ModuleBootstrap.java
@@ -20,7 +20,6 @@ import java.util.Properties;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -44,9 +43,6 @@ public class ModuleBootstrap implements CommandLineRunner {
 	@Autowired
 	private ModuleRunner moduleRunner;
 
-	@Value("${module}")
-	private String moduleDefinition;
-
 	@Autowired
 	@Qualifier("moduleOptions")
 	private Properties moduleOptions;
@@ -59,7 +55,7 @@ public class ModuleBootstrap implements CommandLineRunner {
 
 	@Override
 	public void run(String... args) throws Exception {
-		moduleRunner.run(moduleDefinition, moduleOptions, deploymentProperties);
+		moduleRunner.run(deployer.getModule(), moduleOptions, deploymentProperties);
 	}
 
 	public static void main(String[] args) throws InterruptedException {
@@ -69,7 +65,7 @@ public class ModuleBootstrap implements CommandLineRunner {
 				.child(ServiceConfiguration.class) // so these 2 levels satisfy an assertion (temporary)
 				.child(PluginConfiguration.class)
 				.child(DeployerConfiguration.class, ModuleBootstrap.class)
-				.properties("xd.config.home:META-INF", "module:ticktock.source.time.0")
+				.properties("xd.config.home:META-INF")
 			.run(args);
 		// @formatter:on
 	}

--- a/src/main/java/xolpoc/app/ModuleBootstrap.java
+++ b/src/main/java/xolpoc/app/ModuleBootstrap.java
@@ -55,14 +55,14 @@ public class ModuleBootstrap {
 	private MessageBus messageBus;
 
 	public static void main(String[] args) throws InterruptedException {
-		System.setProperty("xd.config.home", "META-INF");
 		ConfigurableApplicationContext context = new SpringApplicationBuilder()
 				.sources(EmptyConfiguration.class) // this hierarchical depth is expected
 				.child(ServiceConfiguration.class) // so these 2 levels satisfy an assertion (temporary)
 				.child(ModuleBootstrap.class)
 				.child(DeployerConfiguration.class)
+				.properties("xd.config.home:META-INF", "module:ticktock.source.time.0")
 				.run(args);
-		String moduleDefinition = context.getEnvironment().getProperty("module", "ticktock.source.time.0");
+		String moduleDefinition = context.getEnvironment().getProperty("module");
 		ModuleRunner runner = new ModuleRunner(context.getBean(ModuleRegistry.class), context.getBean(ModuleDeployer.class));
 		Properties moduleOptions = new Properties();
 		ModuleDeploymentProperties deploymentProperties = new ModuleDeploymentProperties();

--- a/src/main/java/xolpoc/app/ModuleBootstrap.java
+++ b/src/main/java/xolpoc/app/ModuleBootstrap.java
@@ -24,11 +24,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.xd.dirt.module.ModuleDeployer;
-import org.springframework.xd.dirt.module.ModuleRegistry;
 import org.springframework.xd.module.ModuleDeploymentProperties;
 
 import xolpoc.config.DeployerConfiguration;
+import xolpoc.config.DeployerProperties;
 import xolpoc.config.EmptyConfiguration;
 import xolpoc.config.PluginConfiguration;
 import xolpoc.config.ServiceConfiguration;
@@ -43,10 +42,7 @@ import xolpoc.core.ModuleRunner;
 public class ModuleBootstrap implements CommandLineRunner {
 
 	@Autowired
-	private ModuleRegistry moduleRegistry;
-
-	@Autowired
-	private ModuleDeployer moduleDeployer;
+	private ModuleRunner moduleRunner;
 
 	@Value("${module}")
 	private String moduleDefinition;
@@ -58,10 +54,12 @@ public class ModuleBootstrap implements CommandLineRunner {
 	@Autowired
 	private ModuleDeploymentProperties deploymentProperties;
 
+	@Autowired
+	private DeployerProperties deployer;
+
 	@Override
 	public void run(String... args) throws Exception {
-		ModuleRunner runner = new ModuleRunner(moduleRegistry, moduleDeployer);
-		runner.run(moduleDefinition, moduleOptions, deploymentProperties);
+		moduleRunner.run(moduleDefinition, moduleOptions, deploymentProperties);
 	}
 
 	public static void main(String[] args) throws InterruptedException {

--- a/src/main/java/xolpoc/config/DeployerConfiguration.java
+++ b/src/main/java/xolpoc/config/DeployerConfiguration.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -31,6 +29,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.xd.dirt.module.ModuleDeployer;
+import org.springframework.xd.dirt.module.ModuleRegistry;
 import org.springframework.xd.dirt.module.ResourceModuleRegistry;
 import org.springframework.xd.dirt.plugins.job.JobPluginMetadataResolver;
 import org.springframework.xd.dirt.plugins.stream.ModuleTypeConversionPluginMetadataResolver;
@@ -41,18 +40,25 @@ import org.springframework.xd.module.options.DelegatingModuleOptionsMetadataReso
 import org.springframework.xd.module.options.EnvironmentAwareModuleOptionsMetadataResolver;
 import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
 
+import xolpoc.core.ModuleRunner;
+
 /**
  * Instantiates the components required for loading and deploying Modules.
  *
  * @author Mark Fisher
  */
 @Configuration
-@EnableAutoConfiguration
 @EnableConfigurationProperties(DeployerProperties.class)
 public class DeployerConfiguration {
 	
 	@Autowired
-	DeployerProperties deployer;
+	private DeployerProperties deployer;
+
+	@Bean
+	public ModuleRunner moduleRunner(ModuleRegistry moduleRegistry,
+			ModuleDeployer moduleDeployer) {
+		return new ModuleRunner(moduleRegistry, moduleDeployer,deployer.getInput(), deployer.getOutput());
+	}
 
 	@Bean
 	public ModuleDeployer moduleDeployer() {
@@ -104,22 +110,6 @@ public class DeployerConfiguration {
 		DefaultModuleOptionsMetadataResolver resolver = new DefaultModuleOptionsMetadataResolver();
 		//resolver.setCompositeResolver(moduleOptionsMetadataResolver());
 		return resolver;
-	}
-
-}
-
-@ConfigurationProperties("xd")
-class DeployerProperties {
-
-	@Value("file:${XD_HOME:${xdHome:/opt/xd}}/modules")
-	private String module = "file:/opt/xd/modules";
-
-	public String getModule() {
-		return module;
-	}
-
-	public void setModule(String module) {
-		this.module = module;
 	}
 
 }

--- a/src/main/java/xolpoc/config/DeployerConfiguration.java
+++ b/src/main/java/xolpoc/config/DeployerConfiguration.java
@@ -67,7 +67,7 @@ public class DeployerConfiguration {
 
 	@Bean
 	public ResourceModuleRegistry moduleRegistry() {
-		return new ResourceModuleRegistry(deployer.getModule());
+		return new ResourceModuleRegistry(deployer.getModuleHome());
 	}
 
 	@Bean

--- a/src/main/java/xolpoc/config/DeployerConfiguration.java
+++ b/src/main/java/xolpoc/config/DeployerConfiguration.java
@@ -19,7 +19,11 @@ package xolpoc.config;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.xd.dirt.module.ModuleDeployer;
@@ -39,9 +43,11 @@ import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
  */
 @Configuration
 @EnableAutoConfiguration
+@EnableConfigurationProperties(DeployerProperties.class)
 public class DeployerConfiguration {
-
-	private static final String MODULE_HOME = "file:/opt/xd/modules";
+	
+	@Autowired
+	DeployerProperties deployer;
 
 	@Bean
 	public ModuleDeployer moduleDeployer() {
@@ -50,7 +56,7 @@ public class DeployerConfiguration {
 
 	@Bean
 	public ResourceModuleRegistry moduleRegistry() {
-		return new ResourceModuleRegistry(MODULE_HOME);
+		return new ResourceModuleRegistry(deployer.getModule());
 	}
 
 	@Bean
@@ -76,6 +82,22 @@ public class DeployerConfiguration {
 		DefaultModuleOptionsMetadataResolver resolver = new DefaultModuleOptionsMetadataResolver();
 		//resolver.setCompositeResolver(moduleOptionsMetadataResolver());
 		return resolver;
+	}
+
+}
+
+@ConfigurationProperties("xd")
+class DeployerProperties {
+
+	@Value("file:${XD_HOME:${xdHome:/opt/xd}}/modules")
+	private String module = "file:/opt/xd/modules";
+
+	public String getModule() {
+		return module;
+	}
+
+	public void setModule(String module) {
+		this.module = module;
 	}
 
 }

--- a/src/main/java/xolpoc/config/DeployerConfiguration.java
+++ b/src/main/java/xolpoc/config/DeployerConfiguration.java
@@ -18,18 +18,23 @@ package xolpoc.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.xd.dirt.module.ModuleDeployer;
 import org.springframework.xd.dirt.module.ResourceModuleRegistry;
 import org.springframework.xd.dirt.plugins.job.JobPluginMetadataResolver;
 import org.springframework.xd.dirt.plugins.stream.ModuleTypeConversionPluginMetadataResolver;
+import org.springframework.xd.module.ModuleDeploymentProperties;
 import org.springframework.xd.module.core.ModuleFactory;
 import org.springframework.xd.module.options.DefaultModuleOptionsMetadataResolver;
 import org.springframework.xd.module.options.DelegatingModuleOptionsMetadataResolver;
@@ -62,6 +67,23 @@ public class DeployerConfiguration {
 	@Bean
 	public ModuleFactory moduleFactory() {
 		return new ModuleFactory(moduleOptionsMetadataResolver());
+	}
+	
+	@Bean
+	@ConfigurationProperties("property")
+	public ModuleDeploymentProperties moduleDeploymentProperties() {
+		return new ModuleDeploymentProperties();
+	}
+
+	@Bean
+	public Properties moduleOptions(Environment environmemt) {
+		Map<String, Object> map = new RelaxedPropertyResolver(environmemt).getSubProperties("option.");
+		Properties properties = new Properties();
+		for (String key : map.keySet()) {
+			Object value = map.get(key);
+			properties.setProperty(key, value==null ? "null" : value.toString());
+		}
+		return properties;
 	}
 
 	@Bean

--- a/src/main/java/xolpoc/config/DeployerProperties.java
+++ b/src/main/java/xolpoc/config/DeployerProperties.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xolpoc.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("xd")
+public class DeployerProperties {
+
+	@Value("file:${XD_HOME:${xdHome:/opt/xd}}/modules")
+	private String module = "file:/opt/xd/modules";
+	
+	private String input = null;
+
+	private String output = null;
+
+	public String getInput() {
+		return input;
+	}
+
+	public void setInput(String input) {
+		this.input = input;
+	}
+
+	public String getOutput() {
+		return output;
+	}
+
+	public void setOutput(String output) {
+		this.output = output;
+	}
+
+	public String getModule() {
+		return module;
+	}
+
+	public void setModule(String module) {
+		this.module = module;
+	}
+
+}

--- a/src/main/java/xolpoc/config/DeployerProperties.java
+++ b/src/main/java/xolpoc/config/DeployerProperties.java
@@ -23,8 +23,19 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class DeployerProperties {
 
 	@Value("file:${XD_HOME:${xdHome:/opt/xd}}/modules")
-	private String module = "file:/opt/xd/modules";
+	private String moduleHome = "file:/opt/xd/modules";
 	
+	@Value("${XD_MODULE:${module:ticktock.source.time.0}}")
+	private String module;
+	
+	public String getModule() {
+		return module;
+	}
+
+	public void setModule(String module) {
+		this.module = module;
+	}
+
 	private String input = null;
 
 	private String output = null;
@@ -45,12 +56,12 @@ public class DeployerProperties {
 		this.output = output;
 	}
 
-	public String getModule() {
-		return module;
+	public String getModuleHome() {
+		return moduleHome;
 	}
 
-	public void setModule(String module) {
-		this.module = module;
+	public void setModuleHome(String moduleHome) {
+		this.moduleHome = moduleHome;
 	}
 
 }

--- a/src/main/java/xolpoc/config/PluginConfiguration.java
+++ b/src/main/java/xolpoc/config/PluginConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xolpoc.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.xd.dirt.integration.bus.MessageBus;
+import org.springframework.xd.module.core.Plugin;
+
+import xolpoc.plugins.StreamPlugin;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@Configuration
+@Import(PropertyPlaceholderAutoConfiguration.class)
+//@ImportResource({"classpath*:/META-INF/spring-xd/bus/*.xml"})
+@ImportResource({ "classpath*:/META-INF/spring-xd/bus/redis-bus.xml",
+		"classpath*:/META-INF/spring-xd/bus/codec.xml" })
+public class PluginConfiguration {
+
+	@Autowired
+	private MessageBus messageBus;
+
+	@Bean
+	public Plugin streamPlugin() {
+		return new StreamPlugin(messageBus);
+	}
+
+}

--- a/src/main/java/xolpoc/config/ServiceConfiguration.java
+++ b/src/main/java/xolpoc/config/ServiceConfiguration.java
@@ -17,14 +17,14 @@
 package xolpoc.config;
 
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration;
 import org.springframework.cloud.config.java.AbstractCloudConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportResource;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 
 /**
  * Bind to services, either locally or in a Lattice environment.
@@ -37,8 +37,8 @@ import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 public class ServiceConfiguration {
 
 	@Configuration
-	@ConditionalOnExpression("'${PROCESS_GUID:}'!=''")
-	protected static class LatticeConfig extends AbstractCloudConfig {
+	@Profile("cloud")
+	protected static class CloudConfig extends AbstractCloudConfig {
 
 		@Bean
 		RedisConnectionFactory redisConnectionFactory() {
@@ -46,9 +46,10 @@ public class ServiceConfiguration {
 		}
 	}
 
-	@Bean
-	@ConditionalOnExpression("'${PROCESS_GUID:}'==''")
-	public RedisConnectionFactory redisConnectionFactory() {
-		return new JedisConnectionFactory();
+	@Configuration
+	@Profile("!cloud") // TODO: enable this for cloud profile as well?
+	@Import(RedisAutoConfiguration.class)
+	protected static class NoCloudConfig {
 	}
+
 }

--- a/src/main/java/xolpoc/core/ModuleRunner.java
+++ b/src/main/java/xolpoc/core/ModuleRunner.java
@@ -36,20 +36,29 @@ public class ModuleRunner {
 
 	private final ModuleDeployer deployer;
 
-	public ModuleRunner(ModuleRegistry registry, ModuleDeployer deployer) {
+	private final String input;
+
+	private final String output;
+
+	public ModuleRunner(ModuleRegistry registry, ModuleDeployer deployer, String input,
+			String output) {
 		Assert.notNull(registry, "ModuleRegistry must not be null");
 		Assert.notNull(deployer, "ModuleDeployer must not be null");
+		this.input = input;
+		this.output = output;
 		this.registry = registry;
 		this.deployer = deployer;
 	}
 
-	public void run(String moduleDefinition, Properties moduleOptions, ModuleDeploymentProperties deploymentProperties) {
+	public void run(String moduleDefinition, Properties moduleOptions,
+			ModuleDeploymentProperties deploymentProperties) {
 		deploy(descriptorFor(moduleDefinition, moduleOptions), deploymentProperties);
 	}
 
 	private ModuleDescriptor descriptorFor(String moduleDefinition, Properties options) {
 		String[] tokens = moduleDefinition.split("\\.");
-		Assert.isTrue(tokens.length == 4, "required module property format: streamname.moduletype.modulename.moduleindex");
+		Assert.isTrue(tokens.length == 4,
+				"required module property format: streamname.moduletype.modulename.moduleindex");
 		String streamName = tokens[0];
 		ModuleType moduleType = ModuleType.valueOf(tokens[1]);
 		String moduleName = tokens[2];
@@ -58,24 +67,18 @@ public class ModuleRunner {
 		ModuleDefinition definition = registry.findDefinition(moduleName, moduleType);
 
 		ModuleDescriptor.Builder builder = new ModuleDescriptor.Builder()
-				.setModuleDefinition(definition)
-				.setModuleName(moduleName)
-				.setType(moduleType)
-				.setGroup(streamName)
-				.setIndex(moduleIndex);
-		if (System.getProperties().containsKey("input")) {
-			builder.setSourceChannelName(System.getProperty("input"));
-		}
-		if (System.getProperties().containsKey("output")) {
-			builder.setSinkChannelName(System.getProperty("output"));
-		}
+				.setModuleDefinition(definition).setModuleName(moduleName)
+				.setType(moduleType).setGroup(streamName).setIndex(moduleIndex);
+		builder.setSourceChannelName(input);
+		builder.setSinkChannelName(output);
 		for (String key : options.stringPropertyNames()) {
 			builder.setParameter(key, options.getProperty(key));
 		}
 		return builder.build();
 	}
 
-	private void deploy(ModuleDescriptor descriptor, ModuleDeploymentProperties deploymentProperties) {
+	private void deploy(ModuleDescriptor descriptor,
+			ModuleDeploymentProperties deploymentProperties) {
 		Module module = deployer.createModule(descriptor, deploymentProperties);
 		deployer.deploy(module, descriptor);
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+xdHome: /opt/xd
+
 spring:
   profiles:
     active: default

--- a/src/test/java/xolpoc/ModuleRunnerTests.java
+++ b/src/test/java/xolpoc/ModuleRunnerTests.java
@@ -18,23 +18,29 @@ package xolpoc;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
 
-import xolpoc.app.ModuleBootstrap;
+import xolpoc.ModuleRunnerTests.TestConfiguration;
+import xolpoc.config.PluginConfiguration;
 
 /**
  * @author Mark Fisher
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = ModuleBootstrap.class)
+@SpringApplicationConfiguration(classes = {PluginConfiguration.class, TestConfiguration.class})
 @WebAppConfiguration
 public class ModuleRunnerTests {
 
 	@Test
 	public void contextLoads() {
 	}
+	
+	@Configuration
+	@EnableAutoConfiguration
+	protected static class TestConfiguration {}
 
 }


### PR DESCRIPTION
Requires the cloud profile to be active (natch), which is automatic in
Cloud Foundry or in Lattice (with the latest Spring Cloud snapshots)

Builds on #4 (so merge this and ignore #2, #3, #4).
