### PR TITLE
Enable export of channel and handler metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@
 .idea
 .project
 .settings
-artifacts
-bin
-build
+artifacts/
+bin/
+build/
+.factorypath
 dump.rdb
 xd
 *.iml
+.apt_generated/

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,13 @@
 buildscript {
 	ext {
-		springBootVersion = '1.2.3.RELEASE'
+		springBootVersion = '1.3.0.BUILD-SNAPSHOT'
 	}
 	repositories {
+		mavenLocal()
 		mavenCentral()
 	}
 	dependencies {
+		classpath("io.spring.gradle:dependency-management-plugin:0.5.1.RELEASE")
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
 	}
 }
@@ -14,6 +16,7 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'spring-boot' 
+apply plugin: "io.spring.dependency-management"
 
 jar {
 	baseName = 'xolpoc'
@@ -27,6 +30,12 @@ repositories {
 	maven { url "http://repo.spring.io/plugins-snapshot" }
 }
 
+dependencyManagement {
+  imports {
+    mavenBom "org.springframework.boot:spring-boot-starter-parent:${springBootVersion}"
+  }
+}
+
 dependencies {
 	compile("org.springframework.boot:spring-boot-starter-web") {
 		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
@@ -35,12 +44,16 @@ dependencies {
 		exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
 	}
 	compile("org.springframework.boot:spring-boot-starter-log4j")
-	compile("org.springframework.boot:spring-boot-configuration-processor")
+	runtime("org.springframework.boot:spring-boot-configuration-processor")
 	compile("org.springframework.xd:spring-xd-messagebus-redis:1.2.0.BUILD-SNAPSHOT")
 	compile("org.springframework.xd:spring-xd-messagebus-rabbit:1.2.0.BUILD-SNAPSHOT")
 	compile("org.springframework.xd:spring-xd-dirt:1.2.0.BUILD-SNAPSHOT") {
 		exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
 	}
+	compile("org.springframework.integration:spring-integration-xml") {
+		exclude group: 'com.jayway.jsonpath', module: 'json-path'
+	}
+	// compile("com.jayway.jsonpath:json-path:1.2.0")
 	compile("org.springframework.cloud:spring-cloud-lattice-core:1.0.2.BUILD-SNAPSHOT")
 	compile("org.springframework.cloud:spring-cloud-lattice-connector:1.0.2.BUILD-SNAPSHOT")
 	testCompile("org.springframework.boot:spring-boot-starter-test")

--- a/build.gradle
+++ b/build.gradle
@@ -36,19 +36,11 @@ dependencies {
 	}
 	compile("org.springframework.boot:spring-boot-starter-log4j")
 	compile("org.springframework.boot:spring-boot-configuration-processor")
-	compile("org.springframework.data:spring-data-redis:1.5.0.RELEASE")
-	compile("org.springframework.xd:spring-xd-spi-common:1.2.0.BUILD-SNAPSHOT")
 	compile("org.springframework.xd:spring-xd-messagebus-redis:1.2.0.BUILD-SNAPSHOT")
 	compile("org.springframework.xd:spring-xd-messagebus-rabbit:1.2.0.BUILD-SNAPSHOT")
-	compile("org.springframework.xd:spring-xd-codec:1.2.0.BUILD-SNAPSHOT")
-	compile("org.springframework.integration:spring-integration-redis:4.1.4.RELEASE")
-	compile("org.springframework.xd:spring-xd-module:1.2.0.BUILD-SNAPSHOT")
-	compile("org.springframework.xd:spring-xd-module-spi:1.2.0.BUILD-SNAPSHOT")
-	compile("org.springframework.xd:spring-xd-messagebus-spi:1.2.0.BUILD-SNAPSHOT")
 	compile("org.springframework.xd:spring-xd-dirt:1.2.0.BUILD-SNAPSHOT") {
 		exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
 	}
-	compile("org.springframework.cloud:spring-cloud-spring-service-connector:1.1.2.BUILD-SNAPSHOT")
 	compile("org.springframework.cloud:spring-cloud-lattice-core:1.0.2.BUILD-SNAPSHOT")
 	compile("org.springframework.cloud:spring-cloud-lattice-connector:1.0.2.BUILD-SNAPSHOT")
 	testCompile("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/java/xolpoc/app/ModuleBootstrap.java
+++ b/src/main/java/xolpoc/app/ModuleBootstrap.java
@@ -18,9 +18,12 @@ package xolpoc.app;
 
 import java.util.Properties;
 
+import org.springframework.beans.factory.HierarchicalBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.actuate.endpoint.MetricsEndpoint;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.xd.module.ModuleDeploymentProperties;
@@ -41,6 +44,9 @@ import xolpoc.core.ModuleRunner;
 public class ModuleBootstrap implements CommandLineRunner {
 
 	@Autowired
+	private HierarchicalBeanFactory applicationContext;
+
+	@Autowired
 	private ModuleRunner moduleRunner;
 
 	@Autowired
@@ -53,8 +59,14 @@ public class ModuleBootstrap implements CommandLineRunner {
 	@Autowired
 	private DeployerProperties deployer;
 
+	@Autowired
+	private MetricsEndpoint metricsEndpoint;
+
 	@Override
 	public void run(String... args) throws Exception {
+		((DefaultSingletonBeanRegistry) ((HierarchicalBeanFactory) applicationContext
+				.getParentBeanFactory()).getParentBeanFactory()).registerSingleton(
+				"metricsEndpoint", metricsEndpoint);
 		moduleRunner.run(deployer.getModule(), moduleOptions, deploymentProperties);
 	}
 

--- a/src/main/java/xolpoc/config/DeployerConfiguration.java
+++ b/src/main/java/xolpoc/config/DeployerConfiguration.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.MetricsEndpoint;
+import org.springframework.boot.actuate.endpoint.MetricsEndpointMetricReader;
 import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -50,14 +52,15 @@ import xolpoc.core.ModuleRunner;
 @Configuration
 @EnableConfigurationProperties(DeployerProperties.class)
 public class DeployerConfiguration {
-	
+
 	@Autowired
 	private DeployerProperties deployer;
 
 	@Bean
 	public ModuleRunner moduleRunner(ModuleRegistry moduleRegistry,
 			ModuleDeployer moduleDeployer) {
-		return new ModuleRunner(moduleRegistry, moduleDeployer, deployer.getInput(), deployer.getOutput());
+		return new ModuleRunner(moduleRegistry, moduleDeployer, deployer.getInput(),
+				deployer.getOutput());
 	}
 
 	@Bean
@@ -74,26 +77,28 @@ public class DeployerConfiguration {
 	public ModuleFactory moduleFactory() {
 		return new ModuleFactory(moduleOptionsMetadataResolver());
 	}
-	
+
 	@Bean
 	@ConfigurationProperties("property")
 	public ModuleDeploymentProperties moduleDeploymentProperties(Environment environment) {
 		ModuleDeploymentProperties deploymentProperties = new ModuleDeploymentProperties();
-		Map<String, Object> map = new RelaxedPropertyResolver(environment).getSubProperties("property.");
+		Map<String, Object> map = new RelaxedPropertyResolver(environment)
+				.getSubProperties("property.");
 		for (String key : map.keySet()) {
 			Object value = map.get(key);
-			deploymentProperties.put(key, value==null ? "null" : value.toString());
+			deploymentProperties.put(key, value == null ? "null" : value.toString());
 		}
 		return deploymentProperties;
 	}
 
 	@Bean
 	public Properties moduleOptions(Environment environmemt) {
-		Map<String, Object> map = new RelaxedPropertyResolver(environmemt).getSubProperties("option.");
+		Map<String, Object> map = new RelaxedPropertyResolver(environmemt)
+				.getSubProperties("option.");
 		Properties properties = new Properties();
 		for (String key : map.keySet()) {
 			Object value = map.get(key);
-			properties.setProperty(key, value==null ? "null" : value.toString());
+			properties.setProperty(key, value == null ? "null" : value.toString());
 		}
 		return properties;
 	}
@@ -114,8 +119,14 @@ public class DeployerConfiguration {
 	@Bean
 	public DefaultModuleOptionsMetadataResolver defaultModuleOptionsMetadataResolver() {
 		DefaultModuleOptionsMetadataResolver resolver = new DefaultModuleOptionsMetadataResolver();
-		//resolver.setCompositeResolver(moduleOptionsMetadataResolver());
+		// resolver.setCompositeResolver(moduleOptionsMetadataResolver());
 		return resolver;
 	}
 
+	@Bean
+	public MetricsEndpointMetricReader metricsEndpointMetricReader(
+			MetricsEndpoint metricsEndpoint) {
+		return new MetricsEndpointMetricReader(metricsEndpoint);
+	}
+	
 }

--- a/src/main/java/xolpoc/config/EmptyConfiguration.java
+++ b/src/main/java/xolpoc/config/EmptyConfiguration.java
@@ -16,7 +16,10 @@
 
 package xolpoc.config;
 
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
  * Temporary placeholder since a certain hierarchical depth is expected.
@@ -24,6 +27,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Mark Fisher
  */
 @Configuration
+@Import({ PropertyPlaceholderAutoConfiguration.class, JmxAutoConfiguration.class })
 public class EmptyConfiguration {
 
 }

--- a/src/main/java/xolpoc/config/IntegrationMetricsConfiguration.java
+++ b/src/main/java/xolpoc/config/IntegrationMetricsConfiguration.java
@@ -1,0 +1,41 @@
+package xolpoc.config;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.MetricReaderPublicMetrics;
+import org.springframework.boot.actuate.endpoint.MetricsEndpoint;
+import org.springframework.boot.actuate.metrics.integration.SpringIntegrationMetricReader;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.monitor.IntegrationMBeanExporter;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@Configuration
+public class IntegrationMetricsConfiguration {
+	
+	@Autowired
+	private IntegrationMBeanExporter exporter;
+	
+	@Autowired
+	private MetricsEndpoint endpoint;
+
+	private MetricReaderPublicMetrics metrics;
+	
+	@PostConstruct
+	public void init() {
+		metrics = new MetricReaderPublicMetrics(new SpringIntegrationMetricReader(exporter));
+		endpoint.registerPublicMetrics(metrics);
+	}
+	
+	@PreDestroy
+	public void destroy() {
+		if (metrics!=null) {
+			endpoint.unregisterPublicMetrics(metrics);
+		}
+	}
+	
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,10 @@
 xdHome: /opt/xd
+XD_JMX_ENABLED: true
+debug:
+
+security:
+  user:
+    password: password
 
 spring:
   profiles:

--- a/src/test/java/xolpoc/ModuleRunnerTests.java
+++ b/src/test/java/xolpoc/ModuleRunnerTests.java
@@ -16,10 +16,8 @@
 
 package xolpoc;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -38,7 +36,6 @@ import xolpoc.config.PluginConfiguration;
 public class ModuleRunnerTests {
 
 	@Test
-	@Ignore
 	public void contextLoads() {
 	}
 	


### PR DESCRIPTION
Requires Spring Boot Actuator 1.3.0 snapshots to get the new features there
to do with metric export and Spring Integration JMX enhancements.
